### PR TITLE
Updates for PureScript 0.14.0

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,17 +3,17 @@
 A couple of examples of purescript-express usage
 
 ## Installation
-
+In the top-level directory:
 ```
-$ npm install -g bower pulp purescript
+$ npm install -g spago purescript
 $ npm install
-$ bower install
+$ spago -x examples/spago.dhall build
 ```
 
 ## Running
-
+In the top-level directory:
 ```
-$ pulp run -m <example-name>
+$ spago -x examples/spago.dhall run -m <example-name>
 ```
 
 ## Available examples

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,9 +1,0 @@
-{
-    "name": "purescript-express-examples",
-    "repository": "https://github.com/purescript-express/purescript-express/tree/master/examples",
-    "license": "BSD-3-Clause",
-    "dependencies": {
-        "express": "~4.16.3",
-        "body-parser": "~1.18.3"
-    }
-}

--- a/examples/spago.dhall
+++ b/examples/spago.dhall
@@ -1,6 +1,13 @@
-{ name = "express-examples"
-, dependencies =
-  (../spago.dhall).dependencies # [ "console", "effect", "node-fs", "psci-support", "refs", "strings", "node-process" ]
-, packages = (../spago.dhall).packages
-, sources = (../spago.dhall).sources # ["examples/src/**/*.purs"]
-}
+let conf = ../spago.dhall
+in conf //
+  { dependencies =
+      conf.dependencies #
+        [ "integers"
+        , "node-process"
+        , "refs"
+        ]
+  , sources =
+      conf.sources #
+        [ "examples/**/*.purs"
+        ]
+  }

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "homepage": "https://github.com/purescript-express/purescript-express#readme",
   "dependencies": {
     "express": "^4.17.1"
+  },
+  "devDependencies": {
+    "body-parser": "^1.19.0"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20201206/packages.dhall sha256:c9ffd7577fb8ee2197309591d7ccc0f506ee37b9078866f0ef159f5abbb1b32b
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210406/packages.dhall sha256:7b6af643c2f61d936878f58b613fade6f3cb39f2b4a310f6095784c7b5285879
 
 in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,13 +1,23 @@
 { name = "express"
 , dependencies =
   [ "aff"
+  , "arrays"
   , "console"
   , "effect"
+  , "either"
+  , "exceptions"
   , "foreign"
   , "foreign-generic"
+  , "foreign-object"
+  , "functions"
+  , "maybe"
   , "node-http"
+  , "prelude"
   , "psci-support"
+  , "strings"
   , "test-unit"
+  , "transformers"
+  , "unsafe-coerce"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/test/Test/Handler.js
+++ b/test/Test/Handler.js
@@ -11,3 +11,7 @@ exports.unsafeUpdateMapInPlace = function(map) {
         };
     };
 }
+
+exports.unsafeStringify = function(x) {
+    return JSON.stringify(x);
+}

--- a/test/Test/Handler.purs
+++ b/test/Test/Handler.purs
@@ -24,11 +24,11 @@ import Data.Either (either)
 import Foreign (Foreign, unsafeToForeign, readString)
 import Foreign.Class (encode, decode)
 import Foreign.Object (Object)
-import Global.Unsafe (unsafeStringify)
 
 
 foreign import cwdJson :: String
 foreign import unsafeUpdateMapInPlace :: forall a. Object a -> String -> a -> Effect Unit
+foreign import unsafeStringify :: forall a. a -> String
 
 id :: forall a. a -> a
 id a = a


### PR DESCRIPTION
Resolves #109. This applies necessary updates in order to build and test for PureScript v0.14.0:
* Fixed warnings about used unspecified transitive dependencies emitted by Spago 0.20.0.
* Inlined `unsafeStringify` from the deprecated `globals` package.

I also took some liberty in updating the `examples` directory to get it to play nicely with `spago`.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
